### PR TITLE
implement `emulate` API

### DIFF
--- a/emulate/function.json
+++ b/emulate/function.json
@@ -1,0 +1,18 @@
+{
+	"bindings": [
+		{
+			"authLevel": "anonymous",
+			"type": "httpTrigger",
+			"direction": "in",
+			"name": "req",
+			"methods": ["post"],
+			"route": "emulate/{id}"
+		},
+		{
+			"type": "http",
+			"direction": "out",
+			"name": "$return"
+		}
+	],
+	"scriptFile": "../dist/emulate/index.js"
+}

--- a/emulate/index.test.ts
+++ b/emulate/index.test.ts
@@ -1,0 +1,38 @@
+import test from 'ava'
+import { fake, stub } from 'sinon'
+import * as compute from '../oracle/compute/compute'
+import emulate from './index'
+
+test.serial('Returns the results of the `compute` function', async (t) => {
+	const computeFake = fake(
+		() => Promise.resolve({ packed: 'just a test' }) as any
+	)
+	const factoryStub = stub(compute, 'compute').callsFake(() => computeFake)
+	const res = await emulate({} as any, {
+		params: { id: 'test_id' },
+		body: { network: 'testnet', event: { myParam: 1 } },
+	})
+	t.deepEqual(factoryStub.getCall(0).args, ['test_id', 'testnet'])
+	t.deepEqual(computeFake.getCall(0).args, [{ myParam: 1 }])
+	t.deepEqual(res, { status: 200, body: { packed: 'just a test' } })
+
+	factoryStub.restore()
+})
+
+test.serial(
+	'Returns 400 when throw error from the `compute` function',
+	async (t) => {
+		// eslint-disable-next-line functional/no-promise-reject
+		const computeFake = fake(() => Promise.reject('test'))
+		const factoryStub = stub(compute, 'compute').callsFake(() => computeFake)
+		const res = await emulate({} as any, {
+			params: { id: 'test_id' },
+			body: { network: 'testnet', event: { myParam: 1 } },
+		})
+		t.deepEqual(factoryStub.getCall(0).args, ['test_id', 'testnet'])
+		t.deepEqual(computeFake.getCall(0).args, [{ myParam: 1 }])
+		t.deepEqual(res, { status: 400, body: { packed: undefined } })
+
+		factoryStub.restore()
+	}
+)

--- a/emulate/index.ts
+++ b/emulate/index.ts
@@ -1,0 +1,32 @@
+import { AzureFunction, HttpRequest } from '@azure/functions'
+import { whenDefined } from '@devprotocol/util-ts'
+import { always } from 'ramda'
+import { compute } from '../oracle/compute/compute'
+
+type Response = {
+	readonly status: number
+	readonly body: string | Record<string, unknown>
+	readonly headers?: {
+		readonly [key: string]: string
+	}
+}
+
+const emulate: AzureFunction = async (
+	_,
+	request: HttpRequest
+): Promise<Response> => {
+	const { id = '' } = request.params
+	const { network = '', event } = request.body
+	const computed = await compute(id, network)(event).catch(always(undefined))
+	const status = computed ? 200 : 400
+	const packed = whenDefined(computed, (x) => x.packed)
+
+	return {
+		status,
+		body: {
+			packed,
+		},
+	}
+}
+
+export default emulate

--- a/oracle/compute/compute.test.ts
+++ b/oracle/compute/compute.test.ts
@@ -1,0 +1,57 @@
+import test from 'ava'
+import { ethers } from 'ethers'
+import { fake, spy, stub } from 'sinon'
+import * as executeOraclize from '../executeOraclize/executeOraclize'
+import * as khaosFunctions from '@devprotocol/khaos-functions'
+import * as getData from '../getData/getData'
+import * as getSecret from '../getSecret/getSecret'
+import { MarketQueryData } from '../../common/structs'
+import { compute } from './compute'
+import { NetworkName } from '@devprotocol/khaos-core'
+
+const khaosFunctionsRetuns = { data: { name: 'test', args: [1, 2, 3] } }
+const khaosFunctionsStub = fake(() => Promise.resolve(khaosFunctionsRetuns))
+const factoryCallStub = stub(khaosFunctions, 'call').callsFake(
+	() => khaosFunctionsStub
+)
+const oracleReturns = { khaosId: 'test', result: { test: 'oracle' } as any }
+const oracleStub = fake(() => Promise.resolve(oracleReturns))
+const factoryExecuteOraclizeStub = stub(
+	executeOraclize,
+	'executeOraclize'
+).callsFake(() => oracleStub)
+const getDataSpy = spy(getData, 'getData')
+const getSecretFake = fake((eventData: MarketQueryData) =>
+	Promise.resolve({ secret: { test: 'test' } as any, eventData })
+)
+const getSecretStub = stub(getSecret, 'getSecret').callsFake(getSecretFake)
+
+test.serial('Takes id and network name and runs the process', async (t) => {
+	const event = ({
+		myParam: 1,
+		transactionHash: 'test_tx',
+	} as unknown) as ethers.Event
+	const res = await compute('TEST_ID', 'TEST_NET' as NetworkName)(event)
+	t.deepEqual(factoryCallStub.getCall(0).args, [])
+	t.deepEqual(factoryExecuteOraclizeStub.getCall(0).args, [
+		'TEST_ID',
+		'TEST_NET',
+	])
+	t.deepEqual(getDataSpy.getCall(0).args, [event])
+	t.deepEqual(getSecretStub.getCall(0).args, [getData.getData(event)])
+	t.deepEqual(oracleStub.getCall(0).args, [
+		await getSecretFake(getData.getData(event)),
+	])
+	t.deepEqual(khaosFunctionsStub.getCall(0).args, [
+		{
+			id: 'TEST_ID',
+			method: 'pack',
+			options: { results: oracleReturns.result },
+		},
+	])
+	t.deepEqual(res, {
+		oraclized: oracleReturns,
+		packed: khaosFunctionsRetuns,
+		query: getData.getData(event),
+	})
+})

--- a/oracle/compute/compute.ts
+++ b/oracle/compute/compute.ts
@@ -1,0 +1,34 @@
+import { FunctionPackResults, NetworkName } from '@devprotocol/khaos-core'
+import { ethers } from 'ethers'
+import { executeOraclize, sendInfo } from '../executeOraclize/executeOraclize'
+import { getData } from '../getData/getData'
+import { getSecret } from '../getSecret/getSecret'
+import { call } from '@devprotocol/khaos-functions'
+import { UndefinedOr } from '@devprotocol/util-ts'
+import { MarketQueryData } from '../../common/structs'
+
+type Compute = (
+	event: ethers.Event
+) => Promise<{
+	readonly query: MarketQueryData
+	readonly oraclized: sendInfo
+	readonly packed: UndefinedOr<{
+		readonly data: UndefinedOr<FunctionPackResults>
+	}>
+}>
+
+export const compute = (id: string, network: NetworkName): Compute => {
+	const oracle = executeOraclize(id, network)
+	const khaosFunctions = call()
+	return async (event: ethers.Event): ReturnType<Compute> => {
+		const query = getData(event)
+		const oracleArgs = await getSecret(query)
+		const oraclized = await oracle(oracleArgs)
+		const packed = await khaosFunctions({
+			id,
+			method: 'pack',
+			options: { results: oraclized.result },
+		})
+		return { query, oraclized, packed }
+	}
+}


### PR DESCRIPTION
The `emulate` API is an interface that allows you to execute `oraclize` and get the result of `pack` by passing the same data as the event data of a smart contract.

Developers can predict oracle results in advance by using the `emulate` API.