### PR TITLE
Add `gasLimit` API

### DIFF
--- a/emulate/index.test.ts
+++ b/emulate/index.test.ts
@@ -1,38 +1,124 @@
+/* eslint-disable functional/no-promise-reject */
 import test from 'ava'
+import { BigNumber } from 'ethers'
 import { fake, stub } from 'sinon'
 import * as compute from '../oracle/compute/compute'
+import * as createContract from '../oracle/createContract/createContract'
+import * as estimateTransaction from '../oracle/estimateTransaction/estimateTransaction'
 import emulate from './index'
 
 test.serial('Returns the results of the `compute` function', async (t) => {
 	const computeFake = fake(
-		() => Promise.resolve({ packed: { data: 'just a test' } }) as any
+		() =>
+			Promise.resolve({
+				packed: { data: { name: 'callback', args: [1, 2, 3] } },
+			}) as any
+	)
+	const estimateTransactionFake = fake(() =>
+		Promise.resolve(BigNumber.from('123456'))
 	)
 	const factoryStub = stub(compute, 'compute').callsFake(() => computeFake)
+	const createContractStub = stub(createContract, 'createContract').callsFake(
+		() => Promise.resolve(['just a test instance']) as any
+	)
+	const factoryEstimateTransactionStub = stub(
+		estimateTransaction,
+		'estimateTransaction'
+	).callsFake(() => estimateTransactionFake)
 	const res = await emulate({} as any, {
 		params: { id: 'test_id' },
 		body: { network: 'testnet', event: { myParam: 1 } },
 	})
 	t.deepEqual(factoryStub.getCall(0).args, ['test_id', 'testnet'])
 	t.deepEqual(computeFake.getCall(0).args, [{ myParam: 1 }])
-	t.deepEqual(res, { status: 200, body: { data: 'just a test' } })
+	t.deepEqual(createContractStub.getCall(0).args, ['test_id', 'testnet'] as any)
+	t.deepEqual(factoryEstimateTransactionStub.getCall(0).args, [
+		'just a test instance',
+	] as any)
+	t.deepEqual(estimateTransactionFake.getCall(0).args, ['callback', [1, 2, 3]])
+	t.deepEqual(res, {
+		status: 200,
+		body: {
+			data: { name: 'callback', args: [1, 2, 3], gasLimit: '123456' },
+		},
+	})
 
 	factoryStub.restore()
+	createContractStub.restore()
+	factoryEstimateTransactionStub.restore()
 })
 
 test.serial(
 	'Returns 400 when throw error from the `compute` function',
 	async (t) => {
-		// eslint-disable-next-line functional/no-promise-reject
 		const computeFake = fake(() => Promise.reject('test'))
+		const estimateTransactionFake = fake(() =>
+			Promise.resolve(BigNumber.from('123456'))
+		)
 		const factoryStub = stub(compute, 'compute').callsFake(() => computeFake)
+		const createContractStub = stub(createContract, 'createContract').callsFake(
+			() => Promise.resolve(['just a test']) as any
+		)
+		const factoryEstimateTransactionStub = stub(
+			estimateTransaction,
+			'estimateTransaction'
+		).callsFake(() => estimateTransactionFake)
 		const res = await emulate({} as any, {
 			params: { id: 'test_id' },
 			body: { network: 'testnet', event: { myParam: 1 } },
 		})
 		t.deepEqual(factoryStub.getCall(0).args, ['test_id', 'testnet'])
 		t.deepEqual(computeFake.getCall(0).args, [{ myParam: 1 }])
+		t.deepEqual(createContractStub.getCall(0).args, [
+			'test_id',
+			'testnet',
+		] as any)
+		t.deepEqual(factoryEstimateTransactionStub.getCalls().length, 0)
+		t.deepEqual(estimateTransactionFake.getCalls().length, 0)
 		t.deepEqual(res, { status: 400, body: { data: undefined } })
 
 		factoryStub.restore()
+		createContractStub.restore()
+		factoryEstimateTransactionStub.restore()
+	}
+)
+
+test.serial(
+	'Returns 400 when throw error from the `createContract` function',
+	async (t) => {
+		const computeFake = fake(
+			() =>
+				Promise.resolve({
+					packed: { data: { name: 'callback', args: [1, 2, 3] } },
+				}) as any
+		)
+		const estimateTransactionFake = fake(() =>
+			Promise.resolve(BigNumber.from('123456'))
+		)
+		const factoryStub = stub(compute, 'compute').callsFake(() => computeFake)
+		const createContractStub = stub(createContract, 'createContract').callsFake(
+			() => Promise.reject('test') as any
+		)
+		const factoryEstimateTransactionStub = stub(
+			estimateTransaction,
+			'estimateTransaction'
+		).callsFake(() => estimateTransactionFake)
+		const res = await emulate({} as any, {
+			params: { id: 'test_id' },
+			body: { network: 'testnet', event: { myParam: 1 } },
+		})
+		t.deepEqual(factoryStub.getCall(0).args, ['test_id', 'testnet'])
+		t.deepEqual(computeFake.getCall(0).args, [{ myParam: 1 }])
+		t.deepEqual(createContractStub.getCall(0).args, [
+			'test_id',
+			'testnet',
+		] as any)
+		t.deepEqual(factoryEstimateTransactionStub.getCalls().length, 0)
+		t.deepEqual(estimateTransactionFake.getCalls().length, 0)
+		t.deepEqual(res, { status: 400, body: { data: undefined } })
+
+		factoryStub.restore()
+		createContractStub.restore()
+		factoryEstimateTransactionStub.restore()
 	}
 )

--- a/emulate/index.ts
+++ b/emulate/index.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, HttpRequest } from '@azure/functions'
-import { whenDefinedAll } from '@devprotocol/util-ts'
+import { whenDefined, whenDefinedAll } from '@devprotocol/util-ts'
 import { always } from 'ramda'
 import { compute } from '../oracle/compute/compute'
 import { createContract } from '../oracle/createContract/createContract'
@@ -24,19 +24,19 @@ const emulate: AzureFunction = async (
 		compute(id, network)(event).catch(undef),
 		createContract(id, network).catch(undef),
 	])
-	const estimate = await whenDefinedAll(
+	const estimated = await whenDefinedAll(
 		[computed?.packed?.data, contract?.[0]],
 		([packed, contractInterface]) =>
-			estimateTransaction(contractInterface)(
-				packed.name,
-				packed.args
-			).then((x) => x?.toString())
+			estimateTransaction(contractInterface)(packed.name, packed.args).catch(
+				undef
+			)
 	)
-	const status = computed && estimate ? 200 : 400
-	const body = whenDefinedAll(
-		[computed?.packed?.data, estimate],
-		([packed, gasLimit]) => ({ data: { ...packed, gasLimit } })
-	) || { data: undefined }
+	const gasLimit = whenDefined(estimated, (e) => e.toString())
+	const status = computed ? 200 : 400
+
+	const body = whenDefined(computed?.packed?.data, (packed) => ({
+		data: { ...packed, gasLimit },
+	})) || { data: undefined }
 
 	return {
 		status,

--- a/oracle/createContract/createContract.test.ts
+++ b/oracle/createContract/createContract.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/no-conditional-statement */
+import test from 'ava'
+import { createContract } from './createContract'
+import { ethers } from 'ethers'
+import * as khaos from '@devprotocol/khaos-functions'
+import sinon from 'sinon'
+
+test.serial('returns [Contract, Provider, Wallet]', async (t) => {
+	const stub = sinon
+		.stub(khaos, 'call')
+		.callsFake(() => async (options: any): Promise<any> => {
+			switch (options.method) {
+				case 'abi':
+					return { data: ['event Query()'] }
+				case 'addresses':
+					t.is(options.options.network, 'ropsten')
+					return { data: '0x3cb902625a2b38929f807f9c841f7aecbbce7702' }
+				default:
+					return undefined
+			}
+		})
+	process.env.KHAOS_INFURA_ID = '8e44280aca0d4fbebad2f2849c39a83f'
+	process.env.KHAOS_MNEMONIC =
+		'size wish volume lecture dinner drastic easy assume pledge ribbon bunker stand drill grunt dutch'
+
+	const result = await createContract('test', 'ropsten')
+	t.is(result.length, 3)
+	t.true(result[0] instanceof ethers.Contract)
+	t.true(result[1] instanceof ethers.providers.InfuraProvider)
+	t.true(result[2] instanceof ethers.Wallet)
+	t.is(result[0]?.address, '0x3cb902625a2b38929f807f9c841f7aecbbce7702')
+	stub.restore()
+})
+
+test.serial(
+	'returns [undefined, Provider, Wallet] when the result of khaosFunctions is undefined',
+	async (t) => {
+		const stub = sinon
+			.stub(khaos, 'call')
+			.callsFake(() => async (options: any): Promise<any> => {
+				switch (options.method) {
+					case 'abi':
+						return { data: ['event Query()'] }
+					case 'addresses':
+						return undefined
+					default:
+						return undefined
+				}
+			})
+		process.env.KHAOS_INFURA_ID = '8e44280aca0d4fbebad2f2849c39a83f'
+		process.env.KHAOS_MNEMONIC =
+			'size wish volume lecture dinner drastic easy assume pledge ribbon bunker stand drill grunt dutch'
+
+		const result = await createContract('test', 'mainnet')
+		t.is(result.length, 3)
+		t.is(result[0], undefined)
+		t.true(result[1] instanceof ethers.providers.InfuraProvider)
+		t.true(result[2] instanceof ethers.Wallet)
+		stub.restore()
+	}
+)
+
+test.serial(
+	'returns [Contract, undefined, undefined] when the required environment variables is undefined',
+	async (t) => {
+		const stub = sinon
+			.stub(khaos, 'call')
+			.callsFake(() => async (options: any): Promise<any> => {
+				switch (options.method) {
+					case 'abi':
+						return { data: ['event Query()'] }
+					case 'addresses':
+						return { data: '0x3cb902625a2b38929f807f9c841f7aecbbce7702' }
+					default:
+						return undefined
+				}
+			})
+		delete process.env.KHAOS_INFURA_ID
+
+		const result = await createContract('test', 'mainnet')
+		t.is(result.length, 3)
+		t.true(result[0] instanceof ethers.Contract)
+		t.is(result[1], undefined)
+		t.is(result[2], undefined)
+		stub.restore()
+	}
+)
+
+test.serial(
+	'returns [undefined, undefined, undefined] when the required environment variables is undefined and the result of khaosFunctions is undefined',
+	async (t) => {
+		const stub = sinon
+			.stub(khaos, 'call')
+			.callsFake(() => async (options: any): Promise<any> => {
+				switch (options.method) {
+					case 'abi':
+						return { data: ['event Query()'] }
+					case 'addresses':
+						return undefined
+					default:
+						return undefined
+				}
+			})
+
+		const result = await createContract('test', 'mainnet')
+		t.is(result.length, 3)
+		t.is(result[0], undefined)
+		t.is(result[1], undefined)
+		t.is(result[2], undefined)
+		stub.restore()
+	}
+)

--- a/oracle/createContract/createContract.ts
+++ b/oracle/createContract/createContract.ts
@@ -1,0 +1,50 @@
+import { NetworkName } from '@devprotocol/khaos-core'
+import { call } from '@devprotocol/khaos-functions'
+import { UndefinedOr, whenDefined, whenDefinedAll } from '@devprotocol/util-ts'
+import { ethers } from 'ethers'
+import { always, tryCatch } from 'ramda'
+
+export const createContract = async (
+	id: string,
+	network?: NetworkName
+): Promise<
+	readonly [
+		UndefinedOr<ethers.Contract>,
+		UndefinedOr<ethers.providers.InfuraProvider>,
+		UndefinedOr<ethers.Wallet>
+	]
+> => {
+	const khaosFunctions = call()
+	const [address, abi] = await Promise.all([
+		khaosFunctions({
+			id,
+			method: 'addresses',
+			options: { network },
+		}),
+		khaosFunctions({ id, method: 'abi' }),
+	])
+	const provider = whenDefined(
+		process.env.KHAOS_INFURA_ID,
+		(infura) =>
+			new ethers.providers.InfuraProvider(
+				network === 'mainnet' ? 'homestead' : network,
+				infura
+			)
+	)
+	const wallet = whenDefinedAll(
+		[provider, process.env.KHAOS_MNEMONIC],
+		([prov, mnemonic]) => ethers.Wallet.fromMnemonic(mnemonic).connect(prov)
+	)
+	const contract = await whenDefinedAll(
+		[address?.data, abi?.data],
+		([adr, i]) =>
+			tryCatch(
+				(intf) =>
+					((c) => c.resolvedAddress.then(always(c)).catch(always(undefined)))(
+						new ethers.Contract(adr, intf, wallet)
+					),
+				always(undefined)
+			)(i)
+	)
+	return [contract, provider, wallet]
+}

--- a/oracle/estimateTransaction/estimateTransaction.test.ts
+++ b/oracle/estimateTransaction/estimateTransaction.test.ts
@@ -1,0 +1,65 @@
+import test from 'ava'
+import { estimateTransaction } from './estimateTransaction'
+import { ethers, BigNumber } from 'ethers'
+
+test('returns the value of the `Contract.estimateGas.Methods` result as a string', async (t) => {
+	t.plan(2)
+	const args = ['test', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+	const dummy = ({
+		estimateGas: {
+			testCallback(...callArgs: readonly any[]) {
+				t.deepEqual(callArgs, args)
+				return Promise.resolve(BigNumber.from(123456))
+			},
+		},
+	} as unknown) as ethers.Contract
+	const result = await estimateTransaction(dummy)('testCallback', args)
+	t.is(result?.toString(), '123456')
+})
+
+test('returns undefined when the passed Contract instance has not the method', async (t) => {
+	t.plan(1)
+	const args = ['test', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+	const dummy = ({
+		estimateGas: {
+			testCall() {
+				t.pass()
+				return Promise.resolve(BigNumber.from(123456))
+			},
+		},
+	} as unknown) as ethers.Contract
+	const result = await estimateTransaction(dummy)('testCallback', args)
+	t.is(result, undefined)
+})
+
+test('returns undefined when the passed 2nd argument is undefined', async (t) => {
+	t.plan(1)
+	const dummy = ({
+		estimateGas: {
+			testCallback() {
+				t.pass()
+				return Promise.resolve(BigNumber.from(123456))
+			},
+		},
+	} as unknown) as ethers.Contract
+	const result = await estimateTransaction(dummy)(
+		'testCallback',
+		undefined as any
+	)
+	t.is(result, undefined)
+})
+
+test('returns undefined when throw a error', async (t) => {
+	t.plan(2)
+	const dummy = ({
+		estimateGas: {
+			testCallback() {
+				t.pass()
+				// eslint-disable-next-line functional/no-promise-reject
+				return Promise.reject(new Error('error'))
+			},
+		},
+	} as unknown) as ethers.Contract
+	const result = await estimateTransaction(dummy)('testCallback', [1])
+	t.is(result, undefined)
+})

--- a/oracle/estimateTransaction/estimateTransaction.ts
+++ b/oracle/estimateTransaction/estimateTransaction.ts
@@ -1,0 +1,14 @@
+import { FunctionPackResults } from '@devprotocol/khaos-core'
+import { UndefinedOr, whenDefinedAll } from '@devprotocol/util-ts'
+import { BigNumberish, ethers } from 'ethers'
+import { always } from 'ramda'
+
+export const estimateTransaction = (contract: ethers.Contract) => async (
+	name: string,
+	args: FunctionPackResults['args']
+): Promise<UndefinedOr<BigNumberish>> => {
+	return whenDefinedAll(
+		[contract.estimateGas[name], args],
+		([callback, _args]) => callback(..._args).catch(always(undefined))
+	)
+}

--- a/oracle/sendContractMethod/sendContractMethod.test.ts
+++ b/oracle/sendContractMethod/sendContractMethod.test.ts
@@ -1,4 +1,6 @@
 import test from 'ava'
+import sinon from 'sinon'
+import * as estimateTransaction from '../estimateTransaction/estimateTransaction'
 import { sendContractMethod } from './sendContractMethod'
 
 const tmp = async (): Promise<any> => {
@@ -11,11 +13,26 @@ const dummyConstract = {
 	khaosCallback: tmp,
 }
 
-test('event information is coming back.', async (t) => {
+test.serial('returns event information', async (t) => {
+	const stub = sinon
+		.stub(estimateTransaction, 'estimateTransaction')
+		.callsFake(() => async () => Promise.resolve('123456'))
 	const result = await sendContractMethod(
 		dummyConstract as any
 	)('khaosCallback', ['test', 0])
 	t.deepEqual(result, {
 		hash: '0xdummy',
 	} as any)
+	stub.restore()
+})
+
+test.serial('returns undefined when estimatation is failed', async (t) => {
+	const stub = sinon
+		.stub(estimateTransaction, 'estimateTransaction')
+		.callsFake(() => async () => Promise.resolve(undefined))
+	const result = await sendContractMethod(
+		dummyConstract as any
+	)('khaosCallback', ['test', 0])
+	t.deepEqual(result, undefined)
+	stub.restore()
 })


### PR DESCRIPTION
I added `gasLimit` to the Emulate API response.

This allows developers to know in advance whether a contract call will be successful.